### PR TITLE
Fixes and makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CXX = g++
 CXXFLAGS = -Wextra -Wall
 CXXFLAGS_DEBUG = -Wextra -Wall -g -O0 -DDEBUG
+CXXFLAGS_LINT = -Wall -Wextra -Wpedantic -Werror -Wshadow -Wnull-dereference -Wunused -Wdouble-promotion -Wformat=2 -Wstrict-aliasing=2 -Wstrict-overflow=5 -Wcast-align -Wlogical-op -Wduplicated-cond -Wduplicated-branches -Wuseless-cast
 LIBS = -lraylib
 
 SRC_DIR = src
@@ -56,8 +57,13 @@ endif
 clean:
 	rm -rf $(BUILD_DIR)
 
+lint: $(SRC)
+	$(CXX) $(CXXFLAGS_LINT) -fsyntax-only $<
+	clang-tidy $< --warnings-as-errors=* -- $(CXXFLAGS) $(DEFINES)
+	@echo "Linting completed successfully"
+
 ifneq ($(DEFINES),)
 DEFINES := $(foreach def,$(DEFINES),-D$(def))
 endif
 
-.PHONY: all run release clean debug
+.PHONY: all run release clean debug lint

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -39,7 +39,7 @@ public:
 
     void update()
     {
-        SetMouseCursor(MOUSE_CURSOR_ARROW);
+        // SetMouseCursor(MOUSE_CURSOR_ARROW);
         if (IsWindowResized()) {
             screenSize.x = GetScreenWidth();
             screenSize.y = GetScreenHeight();
@@ -63,6 +63,13 @@ public:
         saveBtn->draw();
 
         auto text = "Current selection: " + sidebar->selectedItem.string();
+
+        #ifdef DEBUG
+        // Draw red horizontal and vertical lines at the mouse position
+        Vector2 mousePos = GetMousePosition();
+        DrawLine(0, mousePos.y, screenSize.x, mousePos.y, RED); // Horizontal line
+        DrawLine(mousePos.x, 0, mousePos.x, screenSize.y, RED); // Vertical line
+        #endif
 
         EndDrawing();
     }

--- a/src/Sidebar.cpp
+++ b/src/Sidebar.cpp
@@ -30,6 +30,31 @@ public:
 
     virtual void update() {
         wasItemSelected = false;
+
+        // Ensure width is properly initialized
+        if (width <= 0) {
+            width = 200; // Default width if not set
+        }
+
+        // Check if the cursor is within the sidebar
+        Vector2 mousePos = GetMousePosition();
+        bool isCursorInsideSidebar = mousePos.x >= 0 && mousePos.x <= width &&
+                                     mousePos.y >= yOffset && mousePos.y <= GetScreenHeight();
+
+        bool isHoveringItem = false;
+        for (size_t i = 0; i < items.size(); ++i) {
+            auto currentY = yOffset + (itemHeight * (i + 1)) - scrollHeight;
+            auto itemBoundingRect = Rectangle{0, (float)currentY, (float)width, (float)itemHeight};
+            if (CheckCollisionPointRec(mousePos, itemBoundingRect)) {
+                isHoveringItem = true;
+                break;
+            }
+        }
+
+        if (isCursorInsideSidebar && !isHoveringItem) {
+            SetMouseCursor(MOUSE_CURSOR_DEFAULT);
+        }
+
         scrollHeight += GetMouseWheelMoveV().y * -scrollSens;
         if (scrollHeight < 0) scrollHeight = 0; // User can't scroll back further than the beginning of the list
         after_update();

--- a/src/SyntaxHighlighter.cpp
+++ b/src/SyntaxHighlighter.cpp
@@ -34,7 +34,7 @@ class Parser {
         grammar = grammarPath;
     }
 
-    HighlightSpan spanAt(long charPos) {
+    HighlightSpan spanAt(unsigned long charPos) {
         for (auto span : spans)
             if (span.start <= charPos && span.end >= charPos)
                 return span;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include <raylib.h>
 #include "MainWindow.cpp"
 #include "debug.hpp"
-//#include <iostream>
 
 int main()
 {


### PR DESCRIPTION
Enhance code editor & sidebar functionality; add linting support and improve cursor handling.

Previously, the cursor would tweak and swap rapidly due to multiple pieces of the code attempting to set it. #3 

There were some parts where `cursorPos - 1 > -1` was used, while this technically works it allows cursor to be negative which is impossible. I replace it with `size_t` and updated the checks. You should probably check this yourself before merging @redstone-dev ... The code editor doesn't let me edit anything right now and I am unsure if that's intentional or even a feature yet.

Also, I've added a `make lint` target that lints with max strictness for compiling and `clang_tidy`, but I've ignored `conversion` warnings since things are commonly converted between `int` and `float` here.